### PR TITLE
Add README for Gradio tunnel usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Photo Album Demo
+
+This repository contains a small demo consisting of a Node.js/React photo album application served inside a Gradio interface.
+
+## Running
+
+1. Install dependencies for the Node.js frontend and backend:
+   ```bash
+   cd server && npm install
+   cd ../client && npm install
+   ```
+2. Install the Python dependency:
+   ```bash
+   pip install gradio
+   ```
+3. Start the app using the Gradio helper:
+   ```bash
+   python gradio_app.py
+   ```
+
+After launching, Gradio prints a **public URL** similar to:
+
+```
+Running on public URL: https://xxxx.gradio.live
+```
+
+Open that link in your browser to use the photo album. The frontend is hosted inside the Gradio interface and no longer needs direct access to `localhost:3000`.


### PR DESCRIPTION
## Summary
- provide instructions for running `gradio_app.py`
- note the public URL output and that port `3000` access isn't needed

## Testing
- `npm test` in `server` (fails: no test specified)
- `npm test` in `client` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_685ce24039388320917d76e077f0e54b