### PR TITLE
Fix API base URL for proxy routing

### DIFF
--- a/client/src/api/upload.ts
+++ b/client/src/api/upload.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { IPhoto, IUploadResponse } from '../types';
 
 // URL-ul de bază pentru API
-const API_URL = 'http://localhost:3001/api';
+const API_URL = '/api';
 
 /**
  * Serviciu pentru încărcare fotografii


### PR DESCRIPTION
## Summary
- update API base URL to use relative `/api` path

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` in `client` *(fails: no tsconfig)*
- `npm run build` in `server` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685ce23a44e88320a05181608d8ed230