### PR TITLE
Fix frontend tunnel creation for gradio 5.x

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -9,7 +9,16 @@ frontend = subprocess.Popen(["npm", "run", "dev", "--", "--host", "0.0.0.0"], cw
 
 # Create a tunnel or proxy to access the frontend
 try:
-    frontend_url = gr.tunneling.create_tunnel(3000)
+    from gradio.networking import setup_tunnel
+    import secrets
+
+    frontend_url = setup_tunnel(
+        local_host="localhost",
+        local_port=3000,
+        share_token=secrets.token_urlsafe(16),
+        share_server_address=None,
+        share_server_tls_certificate=None,
+    )
 except Exception:
     frontend_url = f"/proxy/3000"
 


### PR DESCRIPTION
## Summary
- fix `gradio_app.py` to use `networking.setup_tunnel` for the frontend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ce4b2f8e88320967220458ea5315b