### PR TITLE
fix: close ExifTool on shutdown

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,12 @@
 import express from 'express';
 import cors from 'cors';
 import path from 'path';
-import { uploadMiddleware, uploadPhotos, getAllPhotos } from './routes/upload';
+import {
+  uploadMiddleware,
+  uploadPhotos,
+  getAllPhotos,
+  closeExifTool,
+} from './routes/upload';
 
 // Crearea aplicației Express
 const app = express();
@@ -44,4 +49,22 @@ app.use((err: Error, req: express.Request, res: express.Response, next: express.
 // Pornirea serverului
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
+});
+
+// Închidem ExifTool la ieșirea din proces
+const shutdown = async () => {
+  try {
+    await closeExifTool();
+  } catch (err) {
+    console.error('Error closing ExifTool:', err);
+  }
+};
+
+process.on('SIGINT', async () => {
+  await shutdown();
+  process.exit();
+});
+
+process.on('exit', () => {
+  closeExifTool().catch(err => console.error('Error closing ExifTool:', err));
 });

--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -7,7 +7,10 @@ import { v4 as uuidv4 } from 'uuid';
 import db from '../models/photo';
 
 // Inițializăm ExifTool pentru extragerea metadatelor
-const exiftool = new ExifTool();
+export const exiftool = new ExifTool();
+
+// Funcție de închidere a instanței ExifTool
+export const closeExifTool = () => exiftool.end();
 
 // Configurăm multer pentru upload-uri
 const storage = multer.diskStorage({


### PR DESCRIPTION
## Summary
- export `exiftool` and cleanup helper from upload routes
- close ExifTool when the server process exits

## Testing
- `npm --prefix server install`
- `npm --prefix server run build`


------
https://chatgpt.com/codex/tasks/task_e_685cfe3f2d608320b3b5d169e758566b