### PR TITLE
Fix Gradio launch when FRPC unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ This repository contains a small demo consisting of a Node.js/React photo album 
    python gradio_app.py
    ```
 
+   To expose the interface publicly (useful in Google Colab), set
+   the `GRADIO_SHARE` environment variable:
+
+   ```bash
+   GRADIO_SHARE=true python gradio_app.py
+   ```
+
 After launching, Gradio prints a **public URL** similar to:
 
 ```

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,5 +1,6 @@
 import subprocess
 import atexit
+import os
 import gradio as gr
 
 # Start backend server
@@ -32,4 +33,5 @@ with gr.Blocks() as demo:
     gr.Markdown("# Roma Photo Map")
     gr.HTML(f"<iframe src='{frontend_url}' style='width:100%;height:600px;'></iframe>")
 
-demo.launch(share=True)
+share_env = os.getenv("GRADIO_SHARE", "false").lower() == "true"
+demo.launch(share=share_env)


### PR DESCRIPTION
## Summary
- make `demo.launch` share optional via `GRADIO_SHARE`
- document the env var in README for Colab usage

## Testing
- `python gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_685d05065d8083209c802b6c0f1a6040