### PR TITLE
Fix Vite host check for Gradio

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     port: 3000,
     // Allow requests from any host so that the Vite dev server
     // works when proxied through Gradio's public tunnels.
-    allowedHosts: 'all',
+    // `true` disables host checking entirely.
+    allowedHosts: true,
     proxy: {
       '/api': {
         target: 'http://localhost:3001',


### PR DESCRIPTION
## Summary
- allow requests from any host in Vite dev server config so Gradio share links work

## Testing
- `npm run build` in client
- `npm run build` in server

------
https://chatgpt.com/codex/tasks/task_e_685d0e8832648320b5c29f743e5f8e52