### PR TITLE
Add attraction overlay to photo carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository contains a small demo consisting of a Node.js/React photo album application served inside a Gradio interface.
 
+## Features
+
+- Upload photos from local files or via public links (including Google Drive).
+- EXIF metadata is parsed to extract GPS coordinates.
+- Photos are grouped by location and shown on an interactive map of Rome.
+- Each location opens a carousel with the photos and a short description of the nearest attraction.
+
 ## Running
 
 1. Install dependencies for the Node.js frontend and backend:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -39,6 +39,21 @@ const ROME_ATTRACTIONS: Record<string, IAttraction> = {
     name: 'Vatican',
     description: 'Piazza San Pietro se află în Vatican la picioarele Bazilicii. Una dintre cele mai faimoase piețe din lume.',
     coords: [41.9022, 12.4534]
+  },
+  'St. Peter\'s Basilica': {
+    name: 'Bazilica Sf. Petru',
+    description: 'Cea mai mare biserică catolică din lume, un simbol al creștinismului și capodoperă a arhitecturii renascentiste.',
+    coords: [41.9022, 12.4539]
+  },
+  'Castel Sant\'Angelo': {
+    name: 'Castel Sant\'Angelo',
+    description: 'Fortăreață circulară situată pe malul Tibrului, legată de Vatican printr-un coridor secret.',
+    coords: [41.9039, 12.4663]
+  },
+  'Piazza Navona': {
+    name: 'Piazza Navona',
+    description: 'Una dintre cele mai cunoscute piețe baroce din Roma, celebră pentru Fontana dei Quattro Fiumi.',
+    coords: [41.8989, 12.4731]
   }
 };
 
@@ -83,6 +98,14 @@ const App: React.FC = () => {
   const modalTitle = nearestAttraction
     ? ROME_ATTRACTIONS[nearestAttraction].name
     : (selectedGroupData?.photos[0]?.title || 'Fotografie din Roma');
+
+  const carouselAttractionName = nearestAttraction
+    ? ROME_ATTRACTIONS[nearestAttraction].name
+    : undefined;
+
+  const carouselAttractionDescription = nearestAttraction
+    ? ROME_ATTRACTIONS[nearestAttraction].description
+    : undefined;
   
   // Încărcăm fotografiile la inițializarea componentei
   useEffect(() => {
@@ -175,9 +198,11 @@ const App: React.FC = () => {
         description={modalDescription}
       >
         {selectedGroupData && (
-          <PhotoCarousel 
+          <PhotoCarousel
             photos={selectedGroupData.photos}
             onClose={handleModalClose}
+            attractionName={carouselAttractionName}
+            attractionDescription={carouselAttractionDescription}
           />
         )}
       </Modal>

--- a/client/src/components/PhotoCarousel.css
+++ b/client/src/components/PhotoCarousel.css
@@ -29,3 +29,10 @@
   font-weight: bold;
   margin-right: 0.25rem;
 }
+
+.attraction-info {
+  text-align: center;
+  background-color: #222;
+  color: #fff;
+  padding: 0.5rem;
+}

--- a/client/src/components/PhotoCarousel.tsx
+++ b/client/src/components/PhotoCarousel.tsx
@@ -8,7 +8,9 @@ const PhotoCarousel: React.FC<IPhotoCarouselProps> = ({
   photos,
   onClose,
   onChangeIndex,
-  currentIndex = 0
+  currentIndex = 0,
+  attractionName,
+  attractionDescription
 }) => {
   // Formatarea datei din timestamp-ul fotografiei
   const formatDate = (timestamp: string | null): string => {
@@ -57,6 +59,12 @@ const PhotoCarousel: React.FC<IPhotoCarouselProps> = ({
   
   return (
     <div className="photo-carousel-container">
+      {attractionName && (
+        <div className="attraction-info">
+          <h3>{attractionName}</h3>
+          {attractionDescription && <p>{attractionDescription}</p>}
+        </div>
+      )}
       <Carousel
         selectedItem={currentIndex}
         onChange={onChangeIndex}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -66,6 +66,8 @@ export interface IPhotoCarouselProps {
   onClose?: () => void;
   onChangeIndex?: (index: number) => void;
   currentIndex?: number;
+  attractionName?: string;
+  attractionDescription?: string;
 }
 
 // Proprietăți pentru componenta Modal


### PR DESCRIPTION
## Summary
- show a features section in README
- enrich Rome attractions with extra locations
- expose attraction info as props in PhotoCarousel
- display attraction name/description above carousel

## Testing
- `npm run build` in `server` *(fails: Cannot find module 'express')*
- `npm run build` in `client` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685e659802848320ac1849c1247104fd