### PR TITLE
Add interactive timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a small demo consisting of a Node.js/React photo album 
 - EXIF metadata is parsed to extract GPS coordinates.
 - Photos are grouped by location and shown on an interactive map of Rome.
 - Each location opens a carousel with the photos and a short description of the nearest attraction.
+- Animated timeline view connects photos chronologically on the map and can be shared.
 
 ## Running
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "react-leaflet": "^4.2.1",
         "react-leaflet-cluster": "^2.1.0",
         "react-responsive-carousel": "^3.2.23",
+        "react-router-dom": "^6.23.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -978,6 +979,15 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3114,6 +3124,38 @@
         "classnames": "^2.2.5",
         "prop-types": "^15.5.8",
         "react-easy-swipe": "^0.0.21"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve-from": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,8 @@
     "react-leaflet": "^4.2.1",
     "react-leaflet-cluster": "^2.1.0",
     "react-responsive-carousel": "^3.2.23",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@tsconfig/vite-react": "^6.3.6",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -17,6 +17,16 @@ body {
   text-align: center;
 }
 
+.nav-links a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+.nav-links a:hover {
+  text-decoration: underline;
+}
+
 .main-content {
   flex: 1;
   display: flex;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -158,6 +158,9 @@ const App: React.FC = () => {
       <header className="header">
         <h1>Harta Fotografiilor din Roma</h1>
         <p className="subtitle">Încărcați fotografii cu date GPS și explorați-le pe hartă</p>
+        <nav className="nav-links">
+          <a href="/timeline">Timeline</a>
+        </nav>
       </header>
       
       <main className="main-content">

--- a/client/src/api/upload.ts
+++ b/client/src/api/upload.ts
@@ -97,6 +97,19 @@ const uploadService = {
       console.error('Error fetching photos:', error);
       return [];
     }
+  },
+
+  /**
+   * Obține fotografiile pentru timeline în ordine cronologică
+   */
+  getTimelinePhotos: async (): Promise<IPhoto[]> => {
+    try {
+      const response = await axios.get<{ photos: IPhoto[] }>(`${API_URL}/photos/timeline`);
+      return response.data.photos;
+    } catch (error) {
+      console.error('Error fetching timeline photos:', error);
+      return [];
+    }
   }
 };
 

--- a/client/src/components/Timeline.css
+++ b/client/src/components/Timeline.css
@@ -1,0 +1,20 @@
+.timeline-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.timeline-container .map {
+  height: 400px;
+  width: 100%;
+}
+
+.timeline-photo-info {
+  margin-top: 10px;
+  text-align: center;
+}
+
+.timeline-photo-info img {
+  max-width: 100%;
+  height: auto;
+}

--- a/client/src/components/Timeline.tsx
+++ b/client/src/components/Timeline.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { MapContainer, TileLayer, Polyline, Marker, Popup } from 'react-leaflet';
+import L from 'leaflet';
+import uploadService from '../api/upload';
+import { IPhoto } from '../types';
+import 'leaflet/dist/leaflet.css';
+import './Timeline.css';
+
+const MAP_CONFIG = {
+  center: [41.9028, 12.4964] as [number, number],
+  zoom: 13,
+  minZoom: 5,
+  maxZoom: 18
+};
+
+const Timeline: React.FC = () => {
+  const [photos, setPhotos] = useState<IPhoto[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    const fetchPhotos = async () => {
+      const timelinePhotos = await uploadService.getTimelinePhotos();
+      setPhotos(timelinePhotos);
+    };
+    fetchPhotos();
+  }, []);
+
+  useEffect(() => {
+    if (photos.length === 0) return;
+    const interval = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % photos.length);
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [photos]);
+
+  const path = photos.map((p) => [p.latitude!, p.longitude!] as [number, number]);
+  const currentPhoto = photos[currentIndex];
+
+  const markerIcon = currentPhoto
+    ? new L.Icon({
+        iconUrl: currentPhoto.url,
+        iconSize: [48, 48],
+        className: 'timeline-marker'
+      })
+    : undefined;
+
+  return (
+    <div className="timeline-container">
+      <MapContainer
+        center={MAP_CONFIG.center}
+        zoom={MAP_CONFIG.zoom}
+        minZoom={MAP_CONFIG.minZoom}
+        maxZoom={MAP_CONFIG.maxZoom}
+        scrollWheelZoom={true}
+        className="map"
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        {path.length > 1 && <Polyline positions={path} color="blue" />}
+        {currentPhoto && (
+          <Marker position={[currentPhoto.latitude!, currentPhoto.longitude!]} icon={markerIcon!}>
+            <Popup>
+              <img src={currentPhoto.url} alt={currentPhoto.title} width="160" />
+            </Popup>
+          </Marker>
+        )}
+      </MapContainer>
+      {currentPhoto && (
+        <div className="timeline-photo-info">
+          <img src={currentPhoto.url} alt={currentPhoto.title} />
+          <p>{currentPhoto.title}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Timeline;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import Timeline from './components/Timeline';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './App.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/timeline" element={<Timeline />} />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import path from 'path';
-import { uploadMiddleware, uploadPhotos, uploadPhotosFromUrl, getAllPhotos } from './routes/upload';
+import { uploadMiddleware, uploadPhotos, uploadPhotosFromUrl, getAllPhotos, getTimelinePhotos } from './routes/upload';
 
 // Crearea aplicației Express
 const app = express();
@@ -18,6 +18,7 @@ app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 app.post('/api/upload', uploadMiddleware, uploadPhotos);
 app.post('/api/upload-url', uploadPhotosFromUrl);
 app.get('/api/photos', getAllPhotos);
+app.get('/api/photos/timeline', getTimelinePhotos);
 
 // Ruta pentru verificarea sănătății serverului
 app.get('/health', (req, res) => {

--- a/server/src/models/photo.ts
+++ b/server/src/models/photo.ts
@@ -124,6 +124,31 @@ const PhotoModel = {
       throw error;
     }
   },
+
+  /**
+   * Obține fotografiile ordonate cronologic pentru timeline
+   */
+  getPhotosForTimeline: async (): Promise<IPhotoData[]> => {
+    if (!db) {
+      await initDatabase();
+    }
+
+    if (!db) {
+      throw new Error('Database connection not initialized');
+    }
+
+    try {
+      const photos = await db.all<IPhotoData[]>(
+        `SELECT * FROM photos
+         WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+         ORDER BY COALESCE(timestamp, createdAt) ASC`
+      );
+      return photos;
+    } catch (error) {
+      console.error('Error fetching timeline photos:', error);
+      throw error;
+    }
+  },
   
   /**
    * Obține o fotografie după ID

--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -266,3 +266,22 @@ export const getAllPhotos = async (req: Request, res: Response) => {
     });
   }
 };
+
+/**
+ * Controller pentru fotografiile ordonate pentru timeline
+ */
+export const getTimelinePhotos = async (req: Request, res: Response) => {
+  try {
+    const photos = await db.getPhotosForTimeline();
+    return res.status(200).json({
+      success: true,
+      photos
+    });
+  } catch (error) {
+    console.error('Error fetching timeline photos:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'A apărut o eroare la obținerea fotografiilor pentru timeline: ' + (error instanceof Error ? error.message : 'Eroare necunoscută')
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- show timeline bullet in README
- add API route to fetch photos in chronological order
- implement `getPhotosForTimeline` in SQLite model
- add `/api/photos/timeline` route
- add `getTimelinePhotos` client API call
- integrate React Router and new Timeline component
- add navigation link and styles

## Testing
- `npm run build` in `client`
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_685e83cb9c108320828c7bb68f368909